### PR TITLE
Fixing build: userName and password should be strings.

### DIFF
--- a/refdiff-core/build.gradle
+++ b/refdiff-core/build.gradle
@@ -20,10 +20,10 @@ uploadArchives {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
             // Target repository
             repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-                authentication(userName: ossrhUser, password: ossrhPassword)
+                authentication(userName: 'ossrhUser', password: 'ossrhPassword')
             }
             snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots') {
-                authentication(userName: ossrhUser, password: ossrhPassword)
+                authentication(userName: 'ossrhUser', password: 'ossrhPassword')
             }
             pom.project {
                 name project.name
@@ -58,8 +58,8 @@ uploadArchives {
 }
 
 nexusStaging {  
-    username = ossrhUser
-    password = ossrhPassword
+    username = 'ossrhUser'
+    password = 'ossrhPassword'
 }
 
 dependencies {


### PR DESCRIPTION
Gradle Build was broken because userName and password were defined as properties, instead of strings.